### PR TITLE
Add AdapterPattern project with tests and implementations

### DIFF
--- a/AdapterPattern/AdapterPattern.csproj
+++ b/AdapterPattern/AdapterPattern.csproj
@@ -1,0 +1,25 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
+    <PackageReference Include="Xunit.DependencyInjection" Version="10.6.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="xunit.v3" Version="3.0.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/AdapterPattern/AdapterTests.cs
+++ b/AdapterPattern/AdapterTests.cs
@@ -1,0 +1,118 @@
+﻿using AdapterPattern.Features.Adapter;
+using AdapterPattern.Features.Interfaces;
+
+namespace AdapterPattern
+{
+    //add test collection
+    [Collection(nameof(AdapterTests))]
+    public class AdapterTests
+    {
+        public readonly IRoundPeg _roundPeg;
+        public readonly IRoundHole _roundHole;
+        public readonly ISquarePeg _squarePeg;
+        public readonly ISquarePegAdapter _squarePegAdapter;
+        public AdapterTests(ISquarePeg squarePeg, ISquarePegAdapter squarePegAdapter, IRoundHole roundHole, IRoundPeg roundPeg)
+        {
+            _squarePeg = squarePeg;
+            _squarePegAdapter = squarePegAdapter;
+            _roundHole = roundHole;
+            _roundPeg = roundPeg;
+        }
+
+        [Fact]
+        public void Given_RoundHole_When_RoundPegWithSmallerRadius_Then_Fits()
+        {
+            // Arrange
+            _roundHole.SetRadius(5);
+            _roundPeg.SetRadius(4);
+            // Act
+            var result = _roundHole.Fits(_roundPeg);
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void Given_RoundHole_When_RoundPegWithLargerRadius_Then_DoesNotFit()
+        {
+            // Arrange
+            _roundHole.SetRadius(5);
+            _roundPeg.SetRadius(6);
+            // Act
+            var result = _roundHole.Fits(_roundPeg);
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void Given_RoundHole_When_SquarePegWithSmallerWidth_Then_Fits()
+        {
+            // Arrange
+            _roundHole.SetRadius(5);
+            _squarePeg.SetWidth(5);
+            _squarePegAdapter.SetAdaptee(_squarePeg);
+            // Act
+            var result = _roundHole.Fits(_squarePegAdapter);
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void Given_RoundHole_When_SquarePegWithLargerWidth_Then_DoesNotFit()
+        {
+            // Arrange
+            _roundHole.SetRadius(5);
+            _squarePeg.SetWidth(10);
+            _squarePegAdapter.SetAdaptee(_squarePeg);
+            // Act
+            var result = _roundHole.Fits(_squarePegAdapter);
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void Given_SquarePegAdapter_When_AdapteeNotSet_Then_ThrowsInvalidOperationException()
+        {
+            // Arrange
+            // Act
+            // Assert
+            Assert.Throws<InvalidOperationException>(() => _squarePegAdapter.GetAdaptee());
+        }
+
+        [Fact]
+        public void Given_SquarePegAdapter_When_AdapteeSet_Then_GetAdapteeReturnsAdaptee()
+        {
+            // Arrange
+            _squarePeg.SetWidth(5);
+            _squarePegAdapter.SetAdaptee(_squarePeg);
+            // Act
+            var result = _squarePegAdapter.GetAdaptee();
+            // Assert
+            Assert.Equal(_squarePeg, result);
+        }
+
+        [Fact]
+        public void Given_SquarePegAdapter_When_AdapteeSet_Then_RadiusIsCalculatedCorrectly()
+        {
+            // Arrange
+            _squarePeg.SetWidth(5);
+            _squarePegAdapter.SetAdaptee(_squarePeg);
+            // Act
+            var radius = _squarePegAdapter.Radius;
+            // Assert
+            Assert.Equal(5 * Math.Sqrt(2) / 2, radius);
+        }
+
+        [Fact]
+        public void Given_SquarePegAdapter_When_SetRadius_Then_AdapteeWidthIsSetCorrectly()
+        {
+            // Arrange
+            var expectedWidth = 5;
+            var radius = expectedWidth * Math.Sqrt(2) / 2;
+            _squarePegAdapter.SetAdaptee(_squarePeg);
+            // Act
+            _squarePegAdapter.SetRadius(radius);
+            // Assert
+            Assert.Equal(expectedWidth, _squarePeg.Width);
+        }
+    }
+}

--- a/AdapterPattern/Features/Adapter/ISquarePegAdapter.cs
+++ b/AdapterPattern/Features/Adapter/ISquarePegAdapter.cs
@@ -1,0 +1,10 @@
+﻿using AdapterPattern.Features.Interfaces;
+
+namespace AdapterPattern.Features.Adapter
+{
+    public interface ISquarePegAdapter : IRoundPeg
+    {
+        public void SetAdaptee(ISquarePeg squarePeg);
+        public ISquarePeg GetAdaptee();
+    }
+}

--- a/AdapterPattern/Features/Adapter/SquarePegAdapter.cs
+++ b/AdapterPattern/Features/Adapter/SquarePegAdapter.cs
@@ -1,0 +1,46 @@
+﻿using AdapterPattern.Features.Interfaces;
+
+namespace AdapterPattern.Features.Adapter
+{
+    public class SquarePegAdapter : ISquarePegAdapter
+    {
+        private ISquarePeg? _adaptee;
+
+        public double Radius
+        {
+            get
+            {
+                ValidateAndThrow();
+                return _adaptee.Width * Math.Sqrt(2) / 2;
+            }
+        }
+        public double GetRadius()
+        {
+            return Radius;
+        }
+
+        public void SetRadius(double radius)
+        {
+            var width = radius / Math.Sqrt(2);
+            _adaptee.SetWidth(width * 2);
+        }
+
+        public void SetAdaptee(ISquarePeg squarePeg)
+        {
+            _adaptee = squarePeg;
+        }
+
+        public ISquarePeg GetAdaptee()
+        {
+            ValidateAndThrow();
+            return _adaptee;
+        }
+
+        private void ValidateAndThrow()
+        {
+            if (_adaptee == null)
+                throw new InvalidOperationException("Adaptee is not set.");
+        }
+
+    }
+}

--- a/AdapterPattern/Features/Interfaces/IRoundHole.cs
+++ b/AdapterPattern/Features/Interfaces/IRoundHole.cs
@@ -1,0 +1,10 @@
+﻿namespace AdapterPattern.Features.Interfaces
+{
+    public interface IRoundHole
+    {
+        double Radius { get; }
+        double GetRadius();
+        void SetRadius(double radius);
+        bool Fits(IRoundPeg peg);
+    }
+}

--- a/AdapterPattern/Features/Interfaces/IRoundPeg.cs
+++ b/AdapterPattern/Features/Interfaces/IRoundPeg.cs
@@ -1,0 +1,9 @@
+﻿namespace AdapterPattern.Features.Interfaces
+{
+    public interface IRoundPeg
+    {
+        double Radius { get; }
+        double GetRadius();
+        void SetRadius(double radius);
+    }
+}

--- a/AdapterPattern/Features/Interfaces/ISquarePeg.cs
+++ b/AdapterPattern/Features/Interfaces/ISquarePeg.cs
@@ -1,0 +1,9 @@
+﻿namespace AdapterPattern.Features.Interfaces
+{
+    public interface ISquarePeg
+    {
+        double Width { get; }
+        double GetWidth();
+        void SetWidth(double width);
+    }
+}

--- a/AdapterPattern/Features/RoundHole.cs
+++ b/AdapterPattern/Features/RoundHole.cs
@@ -1,0 +1,30 @@
+﻿using AdapterPattern.Features.Interfaces;
+
+namespace AdapterPattern.Features
+{
+    public class RoundHole : IRoundHole
+    {
+        private double _radius;
+
+        public double Radius
+        {
+            get { return _radius; }
+            private set { _radius = value; }
+        }
+
+        public bool Fits(IRoundPeg peg)
+        {
+            return this.GetRadius() >= peg.GetRadius();
+        }
+
+        public double GetRadius()
+        {
+            return _radius;
+        }
+
+        public void SetRadius(double radius)
+        {
+            Radius = radius;
+        }
+    }
+}

--- a/AdapterPattern/Features/RoundPeg.cs
+++ b/AdapterPattern/Features/RoundPeg.cs
@@ -1,0 +1,23 @@
+﻿using AdapterPattern.Features.Interfaces;
+
+namespace AdapterPattern.Features
+{
+    public class RoundPeg : IRoundPeg
+    {
+        private double _radius;
+        public double Radius
+        {
+            get => _radius;
+            private set => _radius = value;
+        }
+        public double GetRadius()
+        {
+            return _radius;
+        }
+
+        public void SetRadius(double radius)
+        {
+            Radius = radius;
+        }
+    }
+}

--- a/AdapterPattern/Features/SquarePeg.cs
+++ b/AdapterPattern/Features/SquarePeg.cs
@@ -1,0 +1,23 @@
+﻿using AdapterPattern.Features.Interfaces;
+
+namespace AdapterPattern.Features
+{
+    public class SquarePeg : ISquarePeg
+    {
+        private double _width;
+        public SquarePeg() { }
+
+        public double Width
+        {
+            get { return _width; }
+            private set { _width = value; }
+        }
+
+        public double GetWidth() => Width;
+
+        public void SetWidth(double width)
+        {
+            Width = width;
+        }
+    }
+}

--- a/AdapterPattern/Startup.cs
+++ b/AdapterPattern/Startup.cs
@@ -1,0 +1,15 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+
+namespace AdapterPattern
+{
+    internal class Startup
+    {
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddTransient<Features.Interfaces.ISquarePeg, Features.SquarePeg>();
+            services.AddTransient<Features.Interfaces.IRoundPeg, Features.RoundPeg>();
+            services.AddTransient<Features.Interfaces.IRoundHole, Features.RoundHole>();
+            services.AddTransient<Features.Adapter.ISquarePegAdapter, Features.Adapter.SquarePegAdapter>();
+        }
+    }
+}

--- a/DesignPatternsDotNet.sln
+++ b/DesignPatternsDotNet.sln
@@ -19,6 +19,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AbstractFactoryPattern", "A
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FactoryPattern", "FactoryPattern\FactoryPattern.csproj", "{EAE977EE-7585-4DC4-95EF-429EE1BEE095}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AdapterPattern", "AdapterPattern\AdapterPattern.csproj", "{8B478EB4-2DCC-404D-B0E1-F6A5FB398CC8}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -57,6 +59,10 @@ Global
 		{EAE977EE-7585-4DC4-95EF-429EE1BEE095}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{EAE977EE-7585-4DC4-95EF-429EE1BEE095}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{EAE977EE-7585-4DC4-95EF-429EE1BEE095}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8B478EB4-2DCC-404D-B0E1-F6A5FB398CC8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8B478EB4-2DCC-404D-B0E1-F6A5FB398CC8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8B478EB4-2DCC-404D-B0E1-F6A5FB398CC8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8B478EB4-2DCC-404D-B0E1-F6A5FB398CC8}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
- Introduced a new project "AdapterPattern" in the solution.
- Created `AdapterPattern.csproj` targeting .NET 10.0 with necessary package references.
- Added `AdapterTests.cs` for unit testing the adapter pattern functionality.
- Implemented `Startup.cs` for dependency injection configuration.
- Defined and modified classes/interfaces: `RoundHole`, `RoundPeg`, `SquarePeg`, `ISquarePegAdapter`, `SquarePegAdapter`, `IRoundHole`, `IRoundPeg`, and `ISquarePeg` to support the adapter pattern.
- Enabled square pegs to fit into round holes through adaptation.